### PR TITLE
Fix gem to work with rails 5/bootstrap 3

### DIFF
--- a/bootstrap_file_input_rails.gemspec
+++ b/bootstrap_file_input_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'railties', '~> 3.1'
+  spec.add_dependency 'railties', '>= 3.1', '< 6'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/bootstrap_file_input_rails/version.rb
+++ b/lib/bootstrap_file_input_rails/version.rb
@@ -1,3 +1,3 @@
 module BootstrapFileInputRails
-  VERSION = "0.0.1"
+  VERSION = "1.0.0"
 end

--- a/vendor/assets/javascripts/bootstrap.file-input.js
+++ b/vendor/assets/javascripts/bootstrap.file-input.js
@@ -10,89 +10,125 @@
   <a class="btn">Browse</a>
 
 */
-$(function() {
+(function($) {
 
-$('input[type=file]').each(function(i,elem){
+$.fn.bootstrapFileInput = function() {
 
-  // Maybe some fields don't need to be standardized.
-  if (typeof $(this).attr('data-bfi-disabled') != 'undefined') {
-    return;
-  }
+  this.each(function(i,elem){
 
-  // Set the word to be displayed on the button
-  var buttonWord = 'Browse';
+    var $elem = $(elem);
 
-  if (typeof $(this).attr('title') != 'undefined') {
-    buttonWord = $(this).attr('title');
-  }
+    // Add [processed] class to avoid double processing of input file element
+    if (typeof $elem.attr('data-bfi-processed-class') != 'undefined') {
+      // Check if the element already has the [processed] flag on it and skip it if it does
+      if ($elem.hasClass($elem.attr('data-bfi-processed-class'))) {
+          return;
+      }
+      $elem.addClass($elem.attr('data-bfi-processed-class'));
+    }
 
-  // Start by getting the HTML of the input element.
-  // Thanks for the tip http://stackoverflow.com/a/1299069
-  var $elem = $(elem);
-  var input = $('<div>').append( $elem.eq(0).clone() ).html();
+    // Maybe some fields don't need to be standardized.
+    if (typeof $elem.attr('data-bfi-disabled') != 'undefined') {
+      return;
+    }
 
-  // Now we're going to replace that input field with a Bootstrap button.
-  // The input will actually still be there, it will just be float above and transparent (done with the CSS).
-  $elem.replaceWith('<a class="file-input-wrapper btn ' + $elem.attr('class') + '">'+buttonWord+input+'</a>');
-})
-// After we have found all of the file inputs let's apply a listener for tracking the mouse movement.
-// This is important because the in order to give the illusion that this is a button in FF we actually need to move the button from the file input under the cursor. Ugh.
-.promise().done( function(){
+    // Set the word to be displayed on the button
+    var buttonWord = 'Browse';
 
-  // As the cursor moves over our new Bootstrap button we need to adjust the position of the invisible file input Browse button to be under the cursor.
-  // This gives us the pointer cursor that FF denies us
-  $('.file-input-wrapper').mousemove(function(cursor) {
+    if (typeof $elem.attr('title') != 'undefined') {
+      buttonWord = $elem.attr('title');
+    }
 
-    var input, wrapper,
-      wrapperX, wrapperY,
-      inputWidth, inputHeight,
-      cursorX, cursorY;
+    var className = '';
 
-    // This wrapper element (the button surround this file input)
-    wrapper = $(this);
-    // The invisible file input element
-    input = wrapper.find("input");
-    // The left-most position of the wrapper
-    wrapperX = wrapper.offset().left;
-    // The top-most position of the wrapper
-    wrapperY = wrapper.offset().top;
-    // The with of the browsers input field
-    inputWidth= input.width();
-    // The height of the browsers input field
-    inputHeight= input.height();
-    //The position of the cursor in the wrapper
-    cursorX = cursor.pageX;
-    cursorY = cursor.pageY;
+    if (!!$elem.attr('class')) {
+      className = ' ' + $elem.attr('class');
+    }
 
-    //The positions we are to move the invisible file input
-    // The 20 at the end is an arbitrary number of pixels that we can shift the input such that cursor is not pointing at the end of the Browse button but somewhere nearer the middle
-    moveInputX = cursorX - wrapperX - inputWidth + 20;
-    // Slides the invisible input Browse button to be positioned middle under the cursor
-    moveInputY = cursorY- wrapperY - (inputHeight/2);
+    // Now we're going to wrap that input field with a Bootstrap button.
+    // The input will actually still be there, it will just be float above and transparent (done with the CSS).
+    $elem.wrap('<a class="file-input-wrapper btn btn-default ' + className + '"></a>').parent().prepend($('<span></span>').html(buttonWord));
+  })
 
-    // Apply the positioning styles to actually move the invisible file input
-    input.css({
-      left:moveInputX,
-      top:moveInputY
+  // After we have found all of the file inputs let's apply a listener for tracking the mouse movement.
+  // This is important because the in order to give the illusion that this is a button in FF we actually need to move the button from the file input under the cursor. Ugh.
+  .promise().done( function(){
+
+    // As the cursor moves over our new Bootstrap button we need to adjust the position of the invisible file input Browse button to be under the cursor.
+    // This gives us the pointer cursor that FF denies us
+    $('.file-input-wrapper').on('mousemove', function(cursor) {
+
+      var input, wrapper,
+        wrapperX, wrapperY,
+        inputWidth, inputHeight,
+        cursorX, cursorY;
+
+      // This wrapper element (the button surround this file input)
+      wrapper = $(this);
+      // The invisible file input element
+      input = wrapper.find("input");
+      // The left-most position of the wrapper
+      wrapperX = wrapper.offset().left;
+      // The top-most position of the wrapper
+      wrapperY = wrapper.offset().top;
+      // The with of the browsers input field
+      inputWidth= input.width();
+      // The height of the browsers input field
+      inputHeight= input.height();
+      //The position of the cursor in the wrapper
+      cursorX = cursor.pageX;
+      cursorY = cursor.pageY;
+
+      //The positions we are to move the invisible file input
+      // The 20 at the end is an arbitrary number of pixels that we can shift the input such that cursor is not pointing at the end of the Browse button but somewhere nearer the middle
+      moveInputX = cursorX - wrapperX - inputWidth + 20;
+      // Slides the invisible input Browse button to be positioned middle under the cursor
+      moveInputY = cursorY- wrapperY - (inputHeight/2);
+
+      // Apply the positioning styles to actually move the invisible file input
+      input.css({
+        left:moveInputX,
+        top:moveInputY
+      });
     });
+
+    $('body').on('change', '.file-input-wrapper input[type=file]', function(){
+
+      var fileName;
+      fileName = $(this).val();
+
+      // Remove any previous file names
+      $(this).parent().next('.file-input-name').remove();
+      if (!!$(this).prop('files') && $(this).prop('files').length > 1) {
+        var filesLabel = $(this).data('files-label');
+        if (!filesLabel) {
+          filesLabel = 'files';
+        }
+        fileName = $(this)[0].files.length+' '+filesLabel;
+      }
+      else {
+        fileName = fileName.substring(fileName.lastIndexOf('\\') + 1, fileName.length);
+      }
+
+      // Don't try to show the name if there is none
+      if (!fileName) {
+        return;
+      }
+
+      var selectedFileNamePlacement = $(this).data('filename-placement');
+      if (selectedFileNamePlacement === 'inside') {
+        // Print the fileName inside
+        $(this).siblings('span').html(fileName);
+        $(this).attr('title', fileName);
+      } else {
+        // Print the fileName aside (right after the the button)
+        $(this).parent().after('<span class="file-input-name">'+fileName+'</span>');
+      }
+    });
+
   });
 
-  $('.file-input-wrapper input[type=file]').change(function(){
-
-    // Remove any previous file names
-    $(this).parent().next('.file-input-name').remove();
-    if ($(this).prop('files').length > 1) {
-      $(this).parent().after('<span class="file-input-name">'+$(this)[0].files.length+' files</span>');
-    }
-    else {
-      $(this).parent().after('<span class="file-input-name">'+$(this).val().replace('C:\\fakepath\\','')+'</span>');
-    }
-
-  });
-
-  
-
-});
+};
 
 // Add the styles before the first stylesheet
 // This ensures they can be easily overridden with developer styles
@@ -103,4 +139,4 @@ var cssHtml = '<style>'+
   '</style>';
 $('link[rel=stylesheet]').eq(0).before(cssHtml);
 
-});
+})(jQuery);


### PR DESCRIPTION
The current railties version seems to lock the gem on a rather old version, this gem actually works fine with rails 5 and bootstrap 2.3 (or presumably 3 since the upstream bootstrap.file-input.js claims to support it). Since I have updated bootstrap.file-input.js to the latest version as well this presumably adds bootstrap 3 support. 

If you don't mind shipping a new version of this gem when this is merged that would be greatly appreciated.