### PR TITLE
Support rails 6 in gemspec

### DIFF
--- a/bootstrap_file_input_rails.gemspec
+++ b/bootstrap_file_input_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'railties', '>= 3.1', '< 6'
+  spec.add_dependency 'railties', '>= 3.1', '< 7'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Hi there, I just bumped the railties version in the gemspec and tested it, still seems to work as expected. Would it be possible to release a new version with that?

Thanks in advance for any response!